### PR TITLE
Changable about:blank redirect site

### DIFF
--- a/static/assets/scripts/home.js
+++ b/static/assets/scripts/home.js
@@ -29,8 +29,8 @@ if (!inFrame && !navigator.userAgent.includes("Firefox")) {
         style.width = style.height = "100%"
 
         doc.head.appendChild(link);
-        doc.body.appendChild(iframe)
-        location.replace("https://www.nasa.gov/")
+        doc.body.appendChild(iframe);
+        location.replace(localStorage.getItem('panicLink') || 'https://www.nasa.gov/');
     };
 };
 

--- a/static/settings.html
+++ b/static/settings.html
@@ -30,7 +30,7 @@
       </div>
           <div class="settings-card">
         <h3>Set Panic Key</h3>
-        <p>Quickly open a educational site, when the teacher comes.</p>
+        <p>Quickly open a educational site, when the teacher comes. The panic link is also used to redirect you when about:blank windows are opened.</p>
         <input type="text" id="eventKeyInput" placeholder="Panic Key" class="key-form">
         <input class="key-form" placeholder="Panic Link" type="text" id="linkInput" value>
   <button class="key-button" value="Save" onclick="saveEventKey()">Save</button>


### PR DESCRIPTION
Turns the localStorage value `panicLink` into the link used when you open about:blank. If no link is found, nasa.gov is used.