### PR TITLE
Update prettier to 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "express": "^4.18.2"
   },
   "devDependencies": {
-    "prettier": "3.1.1"
+    "prettier": "3.2.1"
   }
 }


### PR DESCRIPTION
Just updates prettier to 3.2.1


The same pull request again because I added a change that was meant for another repo 


