### PR TITLE
Chnage Dockerfile Node image to bookworm-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:iron-bookworm-slim
+FROM node:bookworm-slim
 ENV NODE_ENV=production
 
 WORKDIR /app


### PR DESCRIPTION
fixes vuln [CVE-2023-42282⁠](https://scout.docker.com/vulnerabilities/id/CVE-2023-42282?s=github&n=ip&t=npm&vr=%3E%3D2.0.0%2C%3C2.0.1&utm_source=hub&utm_medium=ExternalLink&_gl=1*8q6h7r*_ga*NzI0NDA4OTcwLjE2ODY3ODI0OTg.*_ga_XJWPQMJYHQ*MTcxMDAwODc4My4zMC4xLjE3MTAwMTA1NTQuNDEuMC4w)