### PR TITLE
fix: path traversal, CORS, cache cap, __dirname, error pages, cookie order

### DIFF
--- a/Masqr.js
+++ b/Masqr.js
@@ -63,9 +63,11 @@ async function MasqFail(req, res) {
   if (!req.headers.host) {
     return
   }
+  if (!/^[a-zA-Z0-9.\-:]+$/.test(req.headers.host)) {
+    return
+  }
   const unsafeSuffix = req.headers.host + ".html"
-  const safeSuffix = path.normalize(unsafeSuffix).replace(/^(\.\.(\/|\\|$))+/, "")
-  const safeJoin = path.join(process.cwd() + "/Masqrd", safeSuffix)
+  const safeJoin = path.join(process.cwd(), "Masqrd", path.basename(unsafeSuffix))
   try {
     await fs.promises.access(safeJoin)
     const FailLocal = await fs.promises.readFile(safeJoin, "utf8")

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createBareServer } from "@nebula-services/bare-server-node";
 import chalk from "chalk";
 import cookieParser from "cookie-parser";
-import cors from "cors";
 import express from "express";
 import basicAuth from "express-basic-auth";
 import mime from "mime";
@@ -14,7 +14,7 @@ import config from "./config.js";
 
 console.log(chalk.yellow("🚀 Starting server..."));
 
-const __dirname = process.cwd();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const server = http.createServer();
 const app = express();
 const bareServer = createBareServer("/ca/");
@@ -69,7 +69,7 @@ app.get("/e/*", async (req, res, next) => {
     const data = Buffer.from(await asset.arrayBuffer());
     const ext = path.extname(reqTarget);
     const no = [".unityweb"];
-    const contentType = no.includes(ext) ? "application/octet-stream" : mime.getType(ext);
+    const contentType = no.includes(ext) ? "application/octet-stream" : (mime.getType(ext) ?? "application/octet-stream");
 
     cache.set(req.path, { data, contentType, timestamp: Date.now() });
     res.writeHead(200, { "Content-Type": contentType });
@@ -91,7 +91,6 @@ app.use(express.urlencoded({ extended: true }));
 } */
 
 app.use(express.static(path.join(__dirname, "static")));
-app.use("/ca", cors({ origin: true }));
 
 const routes = [
   { path: "/b", file: "apps.html" },
@@ -115,11 +114,25 @@ app.use((req, res, next) => {
 
 app.use((err, req, res, next) => {
   console.error(err.stack);
-  res.status(500).sendFile(path.join(__dirname, "static", "404.html"));
+  res.status(500).sendFile(path.join(__dirname, "static", "500.html"));
 });
 
 server.on("request", (req, res) => {
   if (bareServer.shouldRoute(req)) {
+    const origin = req.headers.origin;
+    if (typeof origin === "string" && origin.length > 0) {
+      res.setHeader("Access-Control-Allow-Origin", origin);
+      res.setHeader("Vary", "Origin");
+    } else {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+    }
+    res.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    if (req.method === "OPTIONS") {
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
     bareServer.routeRequest(req, res);
   } else {
     app(req, res);

--- a/static/500.html
+++ b/static/500.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="referrer" content="no-referrer" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="shortcut icon" id="tab-favicon" href="/favicon.png" />
+  <title id="t">Home</title>
+  <link rel="stylesheet" href="/assets/css/global.css?v=6" />
+  <link rel="stylesheet" href="/assets/css/error.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/nav.css?v=01" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+</head>
+
+<body>
+  <div class="f-nav"></div>
+  <div class="main error">
+    <h1>500</h1>
+    <h3>Internal server error.</h3>
+    <p>Something went wrong on our end. Try again in a moment.</p>
+    <button class="one" type="button" onclick="window.location.href = '/';">
+      Go Back Home
+    </button>
+    <button class="two" type="button" onclick="window.location.href = 'https://discord.gg/interstellar'">
+      Join our Discord (Direct)
+    </button>
+    <button class="three" type="button" onclick="go('https://discord.gg/interstellar')">
+      Join our Discord (Proxied)
+    </button>
+  </div>
+</body>
+<script src="/assets/js/index-3.js"></script>
+<script src="/assets/mathematics/bundle.js?v=2025-04-15"></script>
+<script src="/assets/mathematics/config.js?v=2025-04-15"></script>
+<script src="/assets/js/m1.js"></script>
+
+</html>


### PR DESCRIPTION
## Summary

### Security fixes
- Fix path traversal in `Masqr.js` via Host header — validate with allowlist regex, use `path.basename()` instead of incomplete `normalize().replace()`

### Bug fixes
- Fix `__dirname` using `process.cwd()` instead of `import.meta.url` (ESM module — wrong dir when launched from different cwd)
- Fix `mime.getType()` returning `null` for unknown extensions (now falls back to `application/octet-stream`)
- Fix `MasqFail()` calls not being awaited
- Fix `cookieParser` registered after route handlers — moved before routes so Masqr can read cookies on `/e/*`
- Fix 500 error handler incorrectly serving `404.html` — now serves `500.html`
- Fix CORS for bare-server routes — headers now set on raw `http.Server` handler; Express middleware never ran on those routes

### Reliability
- Cap in-memory asset cache at `CACHE_MAX_ENTRIES` (default 1000, env-configurable) to prevent OOM under adversarial traffic
- Add defensive `headersSent` guard in asset proxy error handler

### Error pages
- Add `static/500.html`
- Replace `Failed.html` nginx placeholder with proper license-validation-failed page

### Credentials
- Remove hardcoded default password from `config.js` — credentials now read from `BASIC_AUTH_USERS` env var (`user:pass` CSV)
- Usernames only logged at startup (passwords no longer printed)

## Notes
- Masqr remains **opt-in** via `MASQR=true` env var
- `COOKIE_SECRET` env var required at startup when `MASQR=true`